### PR TITLE
Add live-version tracking for dirty variables

### DIFF
--- a/src/core/project.cpp
+++ b/src/core/project.cpp
@@ -597,9 +597,11 @@ void ProjectBase::_populateAllAttributes()
 
         if (showUI)
         {
+            markShadowValues();
             ImGui::PushID("project_section");
             _projectAttributes();
             ImGui::PopID();
+            markDirtyVariables();
         }
 
         ImGui::Dummy(ScaleSize(0, 8));
@@ -635,6 +637,7 @@ void ProjectBase::_populateAllAttributes()
             scene->_sceneAttributes();
             ///scene->populating_ui = false;
             ImGui::PopID();
+            scene->markDirtyVariables();
 
             /// TODO: Do safely inside mutex? (new function call from worker)
             //scene->updateSceneLiveBuffer();

--- a/src/core/project.h
+++ b/src/core/project.h
@@ -144,6 +144,13 @@ struct VariableEntry
     BaseVariable* shadow_marked = nullptr;
     BaseVariable* live_marked   = nullptr;
 
+    // Track whether shadow value has been edited by the GUI and is awaiting
+    // processing on the live side. 'version' increments on every GUI edit so
+    // external code can detect fresh changes.
+    bool dirty = false;
+    unsigned int version = 0;
+    unsigned int live_version = 0; // last processed version on live side
+
     // Once a live worker change is detected, don't immediately push to shadow buffer.
     // The live buffer reacted to now-expired data, so don't override the latest shadow changes
     // 
@@ -189,6 +196,17 @@ struct VariableMap : public std::vector<VariableEntry>
 {
     void markLiveValues()   { for (size_t i=0; i<size(); i++) at(i).markLiveValue(); }
     void markShadowValues() { for (size_t i=0; i<size(); i++) at(i).markShadowValue(); }
+    void markDirtyIfShadowChanged()
+    {
+        for (auto& entry : *this)
+        {
+            if (entry.shadowChanged())
+            {
+                entry.dirty = true;
+                ++entry.version;
+            }
+        }
+    }
     bool changedShadow() {
         for (size_t i = 0; i < size(); i++)  {
             if (at(i).shadowChanged())
@@ -273,18 +291,26 @@ public:
     {
         DebugPrint("updateLiveBuffers()");
         for (VariableEntry& entry : var_map) {
-            //if (!entry.shadowChanged()) // if we have not changed live since start of worker frame
             entry.updateLive();
+            entry.live_version = entry.version;
+            if (entry.dirty)
+                entry.dirty = false;
         }
     }
     void updateShadowBuffer()
     {
         DebugPrint("updateShadowBuffers()");
         for (VariableEntry& entry : var_map) {
-            if (entry.liveChanged()) // if we have not changed shadow since start of worker frame
+            if (entry.live_version < entry.version)
+                continue; // GUI edit not yet processed on live side
+            if (entry.dirty)
+                continue;
+            if (entry.liveChanged())
                 entry.updateShadow();
         }
     }
+
+    void markDirtyVariables() { var_map.markDirtyIfShadowChanged(); }
 
     void markLiveValues() { var_map.markLiveValues(); }
     void markShadowValues() { var_map.markShadowValues(); }
@@ -357,6 +383,7 @@ protected:
     virtual bool changedShadow() { return false; }
     virtual void markLiveValues() {}
     virtual void markShadowValues() {}
+    virtual void markDirtyVariables() {}
 
     //
     
@@ -474,6 +501,7 @@ protected:
     void updateShadowBuffers() override { DoubleBuffer<VarBufferType>::updateShadowBuffer(); }
     void markLiveValues() override      { DoubleBuffer<VarBufferType>::markLiveValues();   }
     void markShadowValues() override    { DoubleBuffer<VarBufferType>::markShadowValues(); }
+    void markDirtyVariables() override  { DoubleBuffer<VarBufferType>::markDirtyVariables(); }
     bool changedShadow() override       { return DoubleBuffer<VarBufferType>::changedShadow(); }
 };
 
@@ -712,6 +740,12 @@ protected:
     {
         for (SceneBase* scene : viewports.all_scenes)
             scene->markShadowValues();
+    }
+
+    virtual void markDirtyVariables()
+    {
+        for (SceneBase* scene : viewports.all_scenes)
+            scene->markDirtyVariables();
     }
 
     // ---- Project Management ----
@@ -969,12 +1003,17 @@ protected:
         DoubleBuffer<VarBufferType>::markLiveValues();
     }
     void markShadowValues() override
-    { 
+    {
         ProjectBase::markShadowValues(); // call on Scenes
         DoubleBuffer<VarBufferType>::markShadowValues();
     }
+    void markDirtyVariables() override
+    {
+        ProjectBase::markDirtyVariables();
+        DoubleBuffer<VarBufferType>::markDirtyVariables();
+    }
     bool changedShadow() override
-    { 
+    {
         if (ProjectBase::changedShadow()) return true; // call on Scenes
         return DoubleBuffer<VarBufferType>::changedShadow();
     }

--- a/src/core/project_worker.cpp
+++ b/src/core/project_worker.cpp
@@ -110,11 +110,7 @@ void ProjectWorker::worker_loop()
                 }*/
 
                 /// apply shadow data *changes* TO live buffer
-                if (!shared_sync.gui_populated_during_process.load())
-                {
-                    //DebugPrint("pullDataFromShadow()");
-                    pullDataFromShadow();
-                }
+                pullDataFromShadow();
 
                 if (active_project && active_project->changedShadow())
                 {
@@ -154,15 +150,7 @@ void ProjectWorker::worker_loop()
                 // Then don't update shadow OR marked_shadow if the live variables
 
                  // apply live data *changes* TO shadow buffer
-                if (!shared_sync.gui_populated_during_process.load())
-                {
-                    //DebugPrint("pushDataToShadow()");
-                    pushDataToShadow(); // worker frame completed without GUI interruption, Update shadow immediately
-                }
-                ///else
-                ///{
-                ///    DebugPrint("pushDataToShadow() SKIPPED (GUI change means we still need that shadow update)");
-                ///}
+                pushDataToShadow();
   
 
                 DebugPrint("----- END WORKER FRAME -----");


### PR DESCRIPTION
## Summary
- add `live_version` to `VariableEntry`
- record versions when copying shadow to live
- skip shadow updates until the worker processes the GUI version

## Testing
- `cmake -S . -B build` *(fails: Policy "CMP0169" is not known)*
- `cmake --build build -j 4` *(fails: could not load cache)*

------
https://chatgpt.com/codex/tasks/task_e_684050cbd7f4832b9af8abd504fb5bdf